### PR TITLE
Change parse condition of simulator

### DIFF
--- a/config/ios/ios_sdk.gni
+++ b/config/ios/ios_sdk.gni
@@ -80,7 +80,7 @@ assert(!(use_goma && is_chrome_branded && is_official_build &&
 assert(custom_toolchain == "" || additional_target_cpus == [],
        "cannot define both custom_toolchain and additional_target_cpus")
 
-use_ios_simulator = (ios_device_name != "macosx") && (current_cpu == "x86" || current_cpu == "x64")
+use_ios_simulator = (target_environment == "simulator")
 
 # If codesigning is enabled, use must configure either a codesigning identity
 # or a filter to automatically select the codesigning identity.


### PR DESCRIPTION
## Goal 

* Link to iPhoneSimulator SDK while compile with architecture arm64 and simulator environment

## Change Description

* Since Apple Silicon has arm64 simulator, old parsing condition no longer works. It will link to iPhoneOS (device SDK) when compile the slice of arm64 simulator

## Test

* Manually apply this change to [libjingle-build](https://github.com/ubiquiti/libjingle-build) work directory and build success. 

## What To Do Next

* After this is merged, will add a tag `v0.0.12`. Then change `src/build` in file `DEPS` in [ubnt_libjingle](https://github.com/ubiquiti/ubnt_libjingle).